### PR TITLE
ci: add sprout repo's docs to sync with theme

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -8,4 +8,9 @@ group:
       seedcase-project/team
       seedcase-project/seedcase-project
       seedcase-project/decisions
+  - files:
+      - source: _extensions/seedcase-theme/
+        dest: docs/_extensions/seedcase-project/seedcase-theme/
+    repos: |
+      seedcase-project/seedcase-sprout
 


### PR DESCRIPTION
## Description

Connect the seedcase website theme with the soon to be merged Quarto website in the docs folder of Sprout.
