### PR TITLE
ci: :construction_worker: copy extensions into root folder for even Sprout

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -8,9 +8,5 @@ group:
       seedcase-project/team
       seedcase-project/seedcase-website
       seedcase-project/decisions
-  - files:
-      - source: _extensions/seedcase-theme/
-        dest: docs/_extensions/seedcase-project/seedcase-theme/
-    repos: |
       seedcase-project/seedcase-sprout
 


### PR DESCRIPTION
## Description

Restructuring content in Sprout so the Quarto website build assumes the Git root folder, rather than the docs folder.