### PR TITLE
ci: :construction_worker: add `puml-to-svg` workflow and sync to repos

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -3,6 +3,13 @@ group:
       - source: _extensions/seedcase-theme/
         dest: _extensions/seedcase-project/seedcase-theme/
         deleteOrphaned: true
+
+      # Actions
+      - source: .github/workflows/
+        dest: .github/workflows/
+        deleteOrphaned: true
+        exclude: |
+          sync-files.yml
     repos: |
       seedcase-project/community
       seedcase-project/design

--- a/.github/workflows/puml-to-svg.yml
+++ b/.github/workflows/puml-to-svg.yml
@@ -1,0 +1,12 @@
+name: Generate SVG from PlantUML
+
+on:
+  pull_request:
+    paths:
+      - '**.puml'
+
+jobs:
+  generate-plantuml:
+    uses: seedcase-project/.github/.github/workflows/puml-to-svg.yml@main
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

These changes add the `puml-to-svg` workflow as well as synch the workflow files with the website repos.

Closes #51

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review. 
