### PR TITLE
style: :lipstick: increase font size of about link buttons

### DIFF
--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -43,6 +43,7 @@ figcaption {
   border: 1px solid $tertiary !important;
   border-radius: 50px !important;
   color: $primary !important;
+  font-size: 17px !important;
 }
 
 .about-link:hover {


### PR DESCRIPTION

## Description

This increases the font size of about link buttons, so it's the same font size as the content text. I think it was too small before (13px).

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review.

Focus on CHANGES.
