### PR TITLE
style: :lipstick: update about links to have a more modern feel

### DIFF
--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -39,15 +39,16 @@ figcaption {
 }
 
 .about-link {
-  background-color: $secondary !important;
-  border: 1px solid $tertiary !important;
-  border-radius: 50px !important;
+  border: 2px solid $tertiary !important;
   color: $primary !important;
-  font-size: 17px !important;
+  font-size: 20px !important;
+  font-weight: bold;
+  padding: 5px 15px !important;
 }
 
 .about-link:hover {
-  background-color: rgba($secondary, 0.3) !important;
+  background-color: $tertiary !important;
+  color: white !important;
 }
 
 .about-links {

--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -40,6 +40,7 @@ figcaption {
 
 .about-link {
   border: 2px solid $tertiary !important;
+  border-radius: 50px !important;
   color: $primary !important;
   font-size: 20px !important;
   font-weight: bold;


### PR DESCRIPTION
## Description

This PR updates the look of the about links (i.e., the buttons on our landing pages). 
With these changes, I'm moving away from the Sprout "look and feel" that we got from Mjølner earlier, but these buttons look more "modern" (in my opinion). 

Before (+ hover):
![image](https://github.com/user-attachments/assets/d97fccf7-74f8-45d7-8daa-6c749357958c)
![image](https://github.com/user-attachments/assets/96a899f6-1226-431f-987b-b6e6ad787023)

Now (+ hover):
![image](https://github.com/user-attachments/assets/6243f9a4-26e7-4a7b-94db-8973b28b6a70)
![image](https://github.com/user-attachments/assets/2888b5a9-713e-4165-a7b9-c0bbba99f27c)

What do you think? :) 🌱 

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review.
