### PR TITLE
style: 💄 increase banner opacity and bottom padding

### DIFF
--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -60,7 +60,7 @@ figcaption {
   margin: 0 -9999rem;
   /* add back negative margin value */
   padding: 0.25rem 9999rem;
-  background: rgba($secondary, 0.3);
+  background: rgba($secondary, 0.5);
 }
 
 .landing-page-card {

--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -61,6 +61,7 @@ figcaption {
   /* add back negative margin value */
   padding: 0.25rem 9999rem;
   background: rgba($secondary, 0.5);
+  padding-bottom: 30px;
 }
 
 .landing-page-card {


### PR DESCRIPTION
## Description

This PR makes the full-width-banner class a bit more opaque and adds some padding to the bottom of it, so the padding looks the same at the top and the bottom of the banner. 

I'm a **bit** more bold with the colouring with this and #61 :)) 🟢 

Before (ignore the content): 
![image](https://github.com/user-attachments/assets/c5fbddf3-f6ea-4c19-9bbd-40ff2c92fe94)

After: 
![image](https://github.com/user-attachments/assets/84f9f312-a41d-4c91-ba4e-42f0041bfbeb)

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review.