### PR TITLE
style: :lipstick: add padding to hero banner

### DIFF
--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -84,6 +84,8 @@ figcaption {
   background: rgba($secondary, 0.5);
   display: flex;
   justify-content: center;
+  padding-top: 30px;
+  padding-bottom: 10px;
 }
 
 .hero-banner .landing-page-block {

--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -85,7 +85,6 @@ figcaption {
   display: flex;
   justify-content: center;
   padding-top: 30px;
-  padding-bottom: 10px;
 }
 
 .hero-banner .landing-page-block {


### PR DESCRIPTION
## Description

Just to make it a bit prettier. Currently, there's almost no padding at the top of the hero banner. See screenshots below.


From this (look at padding of the hero banner): 

<img src="https://github.com/user-attachments/assets/f2ae390e-1b48-43db-9540-46433640edc7" width=70% height=70%>

To this:

<img src="https://github.com/user-attachments/assets/79b6612d-00f2-42d6-988c-aa9fdc3935a0" width=70% height=70%>

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review.
