### PR TITLE
style: :lipstick: style Python output in Quarto to wrap, not scroll

### DIFF
--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -18,6 +18,12 @@ $toc-active-border: rgb(139, 139, 139); // #8b8b8b;
 $navbar-padding-y: .2rem;
 
 /*-- scss:rules --*/
+
+/* Wrap Python output so it looks nicer */
+.cell-output pre code {
+  white-space: pre-wrap;
+}
+
 .navbar {
   border-bottom: rgba($toc-active-border, 0.3) 1px solid;
 }


### PR DESCRIPTION
## Description

Very small stylistic change so that Python code output gets wrapped so we don't necessarily have to use `pprint()`.
