### PR TITLE
chore: :wrench: use 2 spaces for tabs for all non-Markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,8 +6,12 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+# Have a bit shorter line length for text docs
+[*.{txt,md,qmd}]
 max_line_length = 72
+indent_size = 4

--- a/_extensions/seedcase-theme/glossary.yml
+++ b/_extensions/seedcase-theme/glossary.yml
@@ -1,20 +1,20 @@
 data: |
-    Data can mean any piece of information that someone would like to use
-    to answer questions. What is considered data (and metadata) is highly dependent
-    on people and what they intend to do with information that is collected.
-    In the context of Seedcase Sprout, data is any information collected for the
-    purposes of doing analyses on them to answer questions. An example might be
-    data collected from people participating in a study on health and disease.
+  Data can mean any piece of information that someone would like to use
+  to answer questions. What is considered data (and metadata) is highly dependent
+  on people and what they intend to do with information that is collected.
+  In the context of Seedcase Sprout, data is any information collected for the
+  purposes of doing analyses on them to answer questions. An example might be
+  data collected from people participating in a study on health and disease.
 data package: |
-    A "container" for data that describes a coherent collection of data. It consists
-    of two parts: data resources and properties.
+  A "container" for data that describes a coherent collection of data. It consists
+  of two parts: data resources and properties.
 data resource: |
-    A single piece of data, such as a table or data file, and its properties, included
-    in a data package. It contains the actual data, documented following the Data Package
-    standard.
+  A single piece of data, such as a table or data file, and its properties, included
+  in a data package. It contains the actual data, documented following the Data Package
+  standard.
 properties: |
-    Metadata that describes the entire data package and each of the data resources
-    within it. At the package level, the properties include the package name and
-    description, contributors, licenses, and more. At the resource level, they describe
-    attributes such as the resource name, description, schema, and data fields.
-    All properties are stored in `datapackage.json` in the root directory of the package.
+  Metadata that describes the entire data package and each of the data resources
+  within it. At the package level, the properties include the package name and
+  description, contributors, licenses, and more. At the resource level, they describe
+  attributes such as the resource name, description, schema, and data fields.
+  All properties are stored in `datapackage.json` in the root directory of the package.

--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -21,99 +21,99 @@ $mermaid-edge-color: rgb(139, 139, 139);
 
 /* Wrap Python output so it looks nicer */
 .cell-output pre code {
-    white-space: pre-wrap;
+  white-space: pre-wrap;
 }
 
 .navbar {
-    border-bottom: rgba($toc-active-border, 0.3) 1px solid;
+  border-bottom: rgba($toc-active-border, 0.3) 1px solid;
 }
 
 svg {
-    display: block;
-    max-width: 100%;
-    margin: 0 auto;
-    height: auto !important;
-    width: auto !important;
+  display: block;
+  max-width: 100%;
+  margin: 0 auto;
+  height: auto !important;
+  width: auto !important;
 }
 
 li {
-    margin: 5px 0;
+  margin: 5px 0;
 }
 
 figcaption {
-    text-align: center;
+  text-align: center;
 }
 
 .about-link {
-    border: 2px solid $tertiary !important;
-    border-radius: 50px !important;
-    color: $primary !important;
-    font-size: 20px !important;
-    font-weight: bold;
-    padding: 5px 15px !important;
+  border: 2px solid $tertiary !important;
+  border-radius: 50px !important;
+  color: $primary !important;
+  font-size: 20px !important;
+  font-weight: bold;
+  padding: 5px 15px !important;
 }
 
 .about-link:hover {
-    background-color: $tertiary !important;
-    color: white !important;
+  background-color: $tertiary !important;
+  color: white !important;
 }
 
 .about-links {
-    justify-content: left !important;
-    padding: 10px 0px 0px 0px !important;
+  justify-content: left !important;
+  padding: 10px 0px 0px 0px !important;
 }
 
 .landing-page-block {
-    padding-top: 10px;
-    padding-bottom: 10px;
-    margin-left: 30px;
-    margin-right: 30px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  margin-left: 30px;
+  margin-right: 30px;
 }
 
 @media(min-width: 900px) {
-    .landing-page-block {
-        margin-left: 50px;
-        margin-right: 50px;
-    }
+  .landing-page-block {
+    margin-left: 50px;
+    margin-right: 50px;
+  }
 }
 
 @media (min-width: 1200px) {
-    .landing-page-block {
-        max-width: 900px;
-        margin-left: auto;
-        margin-right: auto;
-    }
+  .landing-page-block {
+    max-width: 900px;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .hero-banner {
-    position: relative;
-    background: rgba($secondary, 0.5);
-    display: flex;
-    justify-content: center;
-    padding-bottom: 30px;
+  position: relative;
+  background: rgba($secondary, 0.5);
+  display: flex;
+  justify-content: center;
+  padding-bottom: 30px;
 }
 
 .hero-banner .landing-page-block {
-    display: flex;
-    flex-direction: row;
+  display: flex;
+  flex-direction: row;
 }
 
 .hero-text>h2,
 .landing-page-block>h2 {
-    margin-top: 0.5rem;
-    border-bottom: none;
+  margin-top: 0.5rem;
+  border-bottom: none;
 }
 
 .landing-page-card {
-    border-radius: 12px;
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.15);
-    background-color: rgba($secondary, 0.3);
-    border: none;
-    padding: 5px 20px 10px 20px;
-    margin-bottom: 40px;
-    justify-content: start !important;
+  border-radius: 12px;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.15);
+  background-color: rgba($secondary, 0.3);
+  border: none;
+  padding: 5px 20px 10px 20px;
+  margin-bottom: 40px;
+  justify-content: start !important;
 }
 
 .navbar-logo {
-    max-height: 38px;
+  max-height: 38px;
 }


### PR DESCRIPTION
## Description

2 spaces for tabs when editing things like YAML files is more than enough. 4 is too much.

<!-- Please delete as appropriate: -->
Doesn't need a review.