### PR TITLE
style: :lipstick: replace Google fonts with Bunny fonts (poppins and roboto-mono)

### DIFF
--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -1,6 +1,6 @@
 /*-- scss:defaults --*/
 
-@import url('https://fonts.bunny.net/css?family=poppins:400roboto-mono:400');
+@import url('@import url(https://fonts.bunny.net/css?family=poppins:400|roboto-mono:400);');
 
 $font-family-sans-serif: "poppins", sans-serif;
 $font-family-monospace: "roboto-mono", monospace;

--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -1,12 +1,9 @@
 /*-- scss:defaults --*/
 
-@import url('https://fonts.googleapis.com/css2?family=Noto Sans');
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code');
-@import url('https://fonts.googleapis.com/css2?family=Maven+Pro');
+@import url('https://fonts.bunny.net/css?family=poppins:400roboto-mono:400');
 
-$font-family-sans-serif: "Maven Pro", sans-serif;
-$font-family-monospace: "Fira Code", monospace;
-$headings-font-family: "Noto Sans", sans-serif;
+$font-family-sans-serif: "poppins", sans-serif;
+$font-family-monospace: "roboto-mono", monospace;
 
 /* brand colour #003224 - the one below is a slightly lighter version of the brand colour */
 /* using rgb to be able to use rgba, i.e., opacity */

--- a/_extensions/seedcase-theme/theme.scss
+++ b/_extensions/seedcase-theme/theme.scss
@@ -1,6 +1,6 @@
 /*-- scss:defaults --*/
 
-@import url('@import url(https://fonts.bunny.net/css?family=poppins:400|roboto-mono:400);');
+@import url('https://fonts.bunny.net/css?family=poppins:400|roboto-mono:400');
 
 $font-family-sans-serif: "poppins", sans-serif;
 $font-family-monospace: "roboto-mono", monospace;


### PR DESCRIPTION
## Description

These changes replace the previously used Google fonts with GDPR compliant [bunny fonts](https://fonts.bunny.net/about). I’ve gone with Poppins and Roboto-mono.

Example: 

![image](https://github.com/user-attachments/assets/806db868-c3cf-41f4-b52a-43f05de18f55)
(Code is Roboto-mono, eveything else is Poppins)

Closes #79 

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
