### PR TITLE
chore: update `.typos.toml` words and exclude svgs

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -6,3 +6,6 @@ extend-exclude = [
   "*.svg"
 ]
 
+[default.extend-words]
+TRE = "TRE" # trusted research environment
+SME = "SME" # small and medium-sized enterprises

--- a/.typos.toml
+++ b/.typos.toml
@@ -3,5 +3,6 @@ extend-exclude = [
   "*.css",
   ".quarto/*",
   "_site/*",
+  "*.svg"
 ]
 


### PR DESCRIPTION
## Description

The poster svg is causing the spell check to fail in `community` and “TRE” and “SME” are abbreviations used in other repos. 

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Ran spell-check
- [X] Ran `just run-all`
