### PR TITLE
chore: :adhesive_bandage: ignore typos in `nnf-application.html`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,7 +3,8 @@ extend-exclude = [
   "*.css",
   ".quarto/*",
   "_site/*",
-  "*.svg"
+  "*.svg",
+  "*nnf-application.html"
 ]
 
 [default.extend-words]


### PR DESCRIPTION
## Description

`nnf-application.html` is located in the `seedcase-website` repo and fails the typos check (bc it's html). So, we’ll ignore it 🙈 

Closes seedcase-project/seedcase-website#322

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
