### PR TITLE
ci: :construction_worker: use GitHub App for adding items to project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -18,6 +18,7 @@ jobs:
   add-to-project:
     uses: seedcase-project/.github/.github/workflows/reusable-add-to-project.yml@main
     with:
+      app-id: ${{ vars.ADD_TO_BOARD_APP_ID }}
       board-number: 18
     secrets:
       add-to-board-token: ${{ secrets.ADD_TO_BOARD }}


### PR DESCRIPTION
## Description

A small fix so that the workflow uses the App ID.

Doesn't need a review.
