### PR TITLE
docs: :memo: add more example styles to `index.qmd`

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -54,5 +54,6 @@ def hello_world():
 ```
 
 {{< glossary data >}}
+{{< glossary properties >}}
 
 {{< glossary table=true >}}

--- a/index.qmd
+++ b/index.qmd
@@ -4,19 +4,20 @@ title: "Welcome"
 
 ## Introduction
 
-This is the test landing page! With a [link](https://duckduckgo.com/)! And an emoji :grin:
+This is the test landing page! With a [link](https://duckduckgo.com/)!
+And an emoji :grin:
 
-And [longer reference to another header](index.qmd#another) in the same document.
+And [longer reference to another header](index.qmd#another) in the same
+document.
 
-Random text:
-The shoes had been there for as long as anyone could remember. In fact, it was
-difficult for anyone to come up with a date they had first appeared. It had
-seemed they'd always been there and yet they seemed so out of place. Why nobody
-had removed them was a question that had been asked time and again, but while
-they all thought it, nobody had ever found the energy to actually do it. So, the
-shoes remained on the steps, out of place in one sense, but perfectly normal in
-another.
-
+Random text: The shoes had been there for as long as anyone could
+remember. In fact, it was difficult for anyone to come up with a date
+they had first appeared. It had seemed they'd always been there and yet
+they seemed so out of place. Why nobody had removed them was a question
+that had been asked time and again, but while they all thought it,
+nobody had ever found the energy to actually do it. So, the shoes
+remained on the steps, out of place in one sense, but perfectly normal
+in another.
 
 Here's a table:
 
@@ -27,9 +28,9 @@ Here's a table:
 
 A list:
 
-1. first
-2. second
-3. third
+1.  first
+2.  second
+3.  third
 
 A callout block:
 
@@ -43,19 +44,19 @@ Some text.
 
 More text.
 
-![This is a caption](_extensions/seedcase-theme/logos/seedcase-logo.svg){width="200"}
+![This is a
+caption](_extensions/seedcase-theme/logos/seedcase-logo.svg){width="200"}
 
 Here's some `inline code` in a sentence.
 
 A code block:
 
-```python
+``` python
 def hello_world():
     print("Hello, world!")
 ```
 
-{{< glossary data >}}
-{{< glossary properties >}}
+{{< glossary data >}} {{< glossary properties >}}
 
 {{< glossary table=true >}}
 

--- a/index.qmd
+++ b/index.qmd
@@ -4,7 +4,8 @@ title: "Welcome"
 
 ## Introduction
 
-This is the test landing page! With a [link](https://duckduckgo.com/)! :grin:
+
+And [longer reference to another header](index.qmd#another) in the same document.
 
 Random text:
 The shoes had been there for as long as anyone could remember. In fact, it was

--- a/index.qmd
+++ b/index.qmd
@@ -4,6 +4,7 @@ title: "Welcome"
 
 ## Introduction
 
+This is the test landing page! With a [link](https://duckduckgo.com/)! And an emoji :grin:
 
 And [longer reference to another header](index.qmd#another) in the same document.
 
@@ -33,7 +34,7 @@ A list:
 A callout block:
 
 ::: callout-tip
-### Testing
+### Header within callout block
 
 Some text.
 :::

--- a/index.qmd
+++ b/index.qmd
@@ -57,3 +57,24 @@ def hello_world():
 {{< glossary properties >}}
 
 {{< glossary table=true >}}
+
+## Simple mermaid diagram
+
+::: column-page
+```{mermaid}
+%%| fig-cap: "Simple mermaid diagram"
+flowchart TB
+    user(["User<br>[person]"])
+    subgraph sprout [Python package]
+        package["Data package functions<br>[Python]<br><br>Create, manage, and check a data package and its 'properties' (metadata)."]
+    end
+    output[("Filesystem<br><br>Stored data and metadata on a local or server filesystem.")]
+
+    user --> sprout:::system
+    package --> metadata
+    sprout --> output:::external
+
+    classDef system fill:none
+    classDef external fill:lightgrey
+```
+:::

--- a/index.qmd
+++ b/index.qmd
@@ -44,6 +44,15 @@ More text.
 
 ![This is a caption](_extensions/seedcase-theme/logos/seedcase-logo.svg){width="200"}
 
+Here's some `inline code` in a sentence.
+
+A code block:
+
+```python
+def hello_world():
+    print("Hello, world!")
+```
+
 {{< glossary data >}}
 
 {{< glossary table=true >}}

--- a/index.qmd
+++ b/index.qmd
@@ -4,7 +4,7 @@ title: "Welcome"
 
 ## Introduction
 
-This is the test landing page! With a [link](https://google.com)! :grin:
+This is the test landing page! With a [link](https://duckduckgo.com/)! :grin:
 
 Random text:
 The shoes had been there for as long as anyone could remember. In fact, it was


### PR DESCRIPTION
## Description

This PR adds more example styles to the index, so it’s easier to get an overview of how theming affects different elements.

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Ran spell-check
- [X] Formatted Markdown
- [X] Ran `just run-all`
