### PR TITLE
ci: :construction_worker: use GitHub App token for syncing files

### DIFF
--- a/.github/workflows/sync-files.yml
+++ b/.github/workflows/sync-files.yml
@@ -9,17 +9,25 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.SYNC_FILES_APP_ID }}
+          private-key: ${{ secrets.SYNC_FILES_TOKEN }}
+
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:
-          GH_PAT: ${{ secrets.SYNC_PAT }}
+          GH_PAT: ${{ steps.app-token.outputs.token }}
           ASSIGNEES: lwjohnst86
           IS_FINE_GRAINED: true
-          GIT_USERNAME: lwjohnst86
-          GIT_EMAIL: lwjohnst@gmail.com
+          GIT_USERNAME: github-actions[bot]
+          GIT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           COMMIT_PREFIX: "chore(sync): :hammer: "
           BRANCH_PREFIX: chore
           TEAM_REVIEWERS: admin


### PR DESCRIPTION
## Description

GitHub App token to sync files, not a personal token.

No review needed.