### PR TITLE
build: :hammer: need to tell uvx to use commitizen for command

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ check-commits:
   number_of_commits=$(git rev-list --count HEAD ^main)
   if [[ ${branch_name} != "main" && ${number_of_commits} -gt 0 ]]
   then
-    uvx cz check --rev-range main..HEAD
+    uvx --from commitizen cz check --rev-range main..HEAD
   else
     echo "Can't either be on ${branch_name} or have more than ${number_of_commits}."
   fi


### PR DESCRIPTION
# Description

`uvx cz` doesn't work because the package is called commitizen, not `cz` so uv gets confused. Need to use `--from`.

No review is needed.