### PR TITLE
feat: :sparkles: add `gitleaks` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ ci:
   autoupdate_commit_msg: "ci(pre-commit): :construction_worker: update pre-commit CI version"
 
 repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.27.2
+    hooks:
+      - id: gitleaks
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:


### PR DESCRIPTION
# Description

To stop credentials and passwords and tokens from being accidentally added.

This PR needs a quick review.
