### PR TITLE
ci: :construction_worker: don't synch to `template-data-package`

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -40,6 +40,7 @@ group:
       seedcase-project/seedcase-website
       seedcase-project/decisions
       seedcase-project/guidebook
+      seedcase-project/template-data-package
 
   - files:
       # Quarto Extensions


### PR DESCRIPTION
# Description

It is a template so should be contained within it's own thing.

No review needed.
