### PR TITLE
Revert "ci: :construction_worker: don't synch to `template-data-package`"

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -40,7 +40,6 @@ group:
       seedcase-project/seedcase-website
       seedcase-project/decisions
       seedcase-project/guidebook
-      seedcase-project/template-data-package
 
   - files:
       # Quarto Extensions


### PR DESCRIPTION
Reverts seedcase-project/seedcase-theme#134

Stupidly added it not removed.