### PR TITLE
feat: :lipstick: lighter weight to dropdown items, were too thick

### DIFF
--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -19,7 +19,7 @@ typography:
   fonts:
     - family: noto sans
       source: "bunny"
-      # other weights are used inexplicitly for e.g., bold and table headers
+      # other weights are used for e.g., bold and table headers
       weight: [300, 500, 600]
     - family: poppins
       source: "bunny"
@@ -138,5 +138,10 @@ defaults:
       }
 
       .callout-body {
+          font-weight: 300 !important;
+      }
+
+      /* Dropdown items on navbar default to 400 weight, but we want them to be lighter. */
+      .dropdown-item {
           font-weight: 300 !important;
       }

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -12,6 +12,10 @@ website:
     left:
       - text: "Welcome"
         href: index.qmd
+      - text: "Menu"
+        menu:
+          - href: index.qmd
+            text: "Home"
   sidebar:
     contents:
       - index.qmd


### PR DESCRIPTION
# Description

Small revision to styling of navbar dropdown items. Sets the weight to 300, rather than the default 400, which made them look a bit too big.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
