### PR TITLE
chore: :art: minor fixes to make settings "JSON compliant"

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,8 +10,7 @@
     "quarto.quarto",
     "pshaddel.conventional-branch",
     "EditorConfig.EditorConfig",
-    "tekumara.typos-vscode",
+    "tekumara.typos-vscode"
   ],
-  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,16 +8,18 @@
   "editor.tabCompletion": "on",
   "editor.snippetSuggestions": "inline",
   "conventional-branch.type": [
-    "build", // Changes that affect the build system or external dependencies
-    "ci", // Changes to our CI configuration files and scripts
-    "docs", // Documentation only changes
-    "feat", // A new feature
-    "fix", // A bug fix
-    "refactor", // A code change that neither fixes a bug nor adds a feature
-    "style", // Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-    "test", // Adding missing tests or correcting existing tests
-    "chore", // Misc things, like renaming or deleting files
+    "build",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "refactor",
+    "style",
+    "test",
+    "chore",
+    "perf",
+    "revert"
   ],
   "conventional-branch.format": "{Type}/{Branch}",
-  "files.insertFinalNewline": true,
+  "files.insertFinalNewline": true
 }


### PR DESCRIPTION
# Description

Technically can't have `//` comments in JSON. My parser/highlighter didn't like these, so I just removed them.

This PR needs a quick review.
