### PR TITLE
style: :lipstick: change code font colour to dark green

### DIFF
--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -151,3 +151,7 @@ defaults:
       .dropdown-item {
           font-weight: 300 !important;
       }
+
+      code {
+        color: $primary;
+      }


### PR DESCRIPTION
# Description

Instead of the default purple, which doesn't really fit the rest of the brand. 

Before: 
<img width="348" height="25" alt="image" src="https://github.com/user-attachments/assets/3f0cedc6-4b12-47c2-836d-22b0d0e0912c" />

Now: 
<img width="347" height="37" alt="image" src="https://github.com/user-attachments/assets/14925bf2-696f-4a85-828d-40757b8ca2b9" />

This PR needs a quick review.

Related to seedcase-project/check-datapackage#8

## Checklist

- [X] Ran `just run-all`
