### PR TITLE
fix: :lipstick: apply h2 styles to all descendants instead of only direct children

### DIFF
--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -123,8 +123,8 @@ defaults:
           flex-direction: row;
       }
 
-      .hero-text>h2,
-      .landing-page-block>h2 {
+      .hero-text h2,
+      .landing-page-block h2 {
           margin-top: 0.5rem;
           border-bottom: none;
       }


### PR DESCRIPTION
# Description

Of hero-text and landing-page-block. This style still doesn't apply to H2 headers outside of these two classes.

Related to seedcase-project/check-datapackage#8.

This PR needs a quick/an in-depth review.

## Checklist

- [X] Ran `just run-all`
