### PR TITLE
style: 💄 add side margins to about link btns for nicer spacing

### DIFF
--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -76,7 +76,7 @@ defaults:
           font-size: 20px !important;
           font-weight: bold;
           padding: 5px 15px !important;
-          margin: 0px 10px 10px 0px;
+          margin: 0px 10px 10px 10px;
       }
 
       .about-link:hover {

--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -76,6 +76,7 @@ defaults:
           font-size: 20px !important;
           font-weight: bold;
           padding: 5px 15px !important;
+          margin: 0px 10px 10px 0px;
       }
 
       .about-link:hover {

--- a/index.qmd
+++ b/index.qmd
@@ -7,6 +7,10 @@ title: "Welcome"
 This is the test landing page! With a [link](https://duckduckgo.com/)!
 And an emoji :grin:
 
+[An about link button](nonexisting-link){.btn .about-link}
+[Another one next to it](nonexisting-link){.btn .about-link}
+
+
 And [longer reference to another header](index.qmd#another) in the same
 document.
 


### PR DESCRIPTION
# Description

I noticed on both our main website and Sprout's that the spacing isn't that nice, so I've added some here.

The bottom margins is to ensure that the spacing is still nice on mobile devices. Before this change, it looked like this: 

<img width="1125" height="2436" alt="image" src="https://github.com/user-attachments/assets/4ade9169-b05b-4b08-9a55-7dd8e8453d4d" />

This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
