### PR TITLE
style: :lipstick:  color built-ins the same as regular variables

### DIFF
--- a/custom-styles.scss
+++ b/custom-styles.scss
@@ -3,3 +3,9 @@
 // See the link below for an overview of the available variables
 // and how to customize them.
 // https://quarto.org/docs/output-formats/html-themes.html#sass-variables
+
+// Color built-ins the same as regular variables
+// since we sometimes use built-in names as parameter names
+span.bu {
+  color: inherit !important
+}


### PR DESCRIPTION
# Description

Color built-ins the same as other variables since we sometimes use built-in names as parameter names and it looks odd that one parameter is colored differently.

Before (you barely see the `type` param):
<img width="777" height="345" alt="image" src="https://github.com/user-attachments/assets/35d7979f-7ac1-4b80-aea8-0d8796af49cb" />

After:
<img width="777" height="345" alt="image" src="https://github.com/user-attachments/assets/804e0940-c7d6-481e-8c2b-8fff3116772a" />

Related to #160.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
