### PR TITLE
style: :lipstick: color terminal executables the same as default variables

### DIFF
--- a/custom-styles.scss
+++ b/custom-styles.scss
@@ -9,3 +9,8 @@
 span.bu {
   color: inherit !important
 }
+// Color terminal executables the same as regular variables
+// since the default has low contrast and is hard to see
+span.ex {
+  color: inherit !important
+}


### PR DESCRIPTION
# Description

I agree with @signekb that its not easy to view the terminal executables since they are in cyan on a light background:

<img width="828" height="233" alt="image" src="https://github.com/user-attachments/assets/62c1f9c3-7350-4832-b304-089ba452eb43" />

This PR changes that so they are just emboldened in the default color:

<img width="608" height="275" alt="image" src="https://github.com/user-attachments/assets/aff6389c-fb56-463e-bce4-ea5101490f2c" />


Closes https://github.com/seedcase-project/seedcase-theme/issues/160

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
