### PR TITLE
style: 💄 add brand `code-bg` and `dark-grey`

### DIFF
--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -16,6 +16,7 @@ color:
     logo-green: "#024639"
     dark-green: "#196440"
     vibrant-green: "#48DC76"
+    dark-grey: "#8B8B8B"
     light-grey: "#F8F9FA"
     code-bg: "#E9ECEFA6"
   primary: dark-green
@@ -44,7 +45,7 @@ typography:
 defaults:
   bootstrap:
     defaults:
-      mermaid-edge-color: "#8B8B8B"
+      mermaid-edge-color: var(--brand-dark-grey)
       # Set code background colour variable so all inline code has the same colour
       # including headers with inline code.
       # This colour is the default background colour for inline code.

--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -17,6 +17,7 @@ color:
     dark-green: "#196440"
     vibrant-green: "#48DC76"
     light-grey: "#F8F9FA"
+    code-bg: "#E9ECEFA6"
   primary: dark-green
   tertiary: vibrant-green
   light: light-grey
@@ -44,6 +45,10 @@ defaults:
   bootstrap:
     defaults:
       mermaid-edge-color: "#8B8B8B"
+      # Set code background colour variable so all inline code has the same colour
+      # including headers with inline code.
+      # This colour is the default background colour for inline code.
+      code-bg: var(--brand-code-bg)
     rules: |
       .cell-output pre code {
         white-space: pre-wrap;

--- a/index.qmd
+++ b/index.qmd
@@ -36,6 +36,9 @@ A list:
 2.  second
 3.  third
 
+![This is a
+caption](_extensions/seedcase-theme/logos/seedcase-logo.svg){width="200"}
+
 A callout block:
 
 ::: callout-tip
@@ -46,10 +49,7 @@ Some text.
 
 ## Another header with `code span`
 
-More text.
 
-![This is a
-caption](_extensions/seedcase-theme/logos/seedcase-logo.svg){width="200"}
 
 Here's some `inline code` in a sentence.
 

--- a/index.qmd
+++ b/index.qmd
@@ -44,7 +44,7 @@ A callout block:
 Some text.
 :::
 
-## Another
+## Another header with `code span`
 
 More text.
 


### PR DESCRIPTION
# Description

This adds a `code-bg` and `dark-grey` to the brand's colour palette and then uses those colours under the bootstrap defaults instead of hardcoding the colours there. It should fix the difference in code colour background (between headers with code and other text with code) that we noticed in seedcase-project/seedcase-flower#44.

Adding the background colour this way also catches other instances of the other, lighter grey being used as background colour as e.g., in the description of [flower's guide](https://flower.seedcase-project.org/docs/guide/).

This PR needs a quick/an in-depth review.

## Checklist

- [X] Ran `just run-all`
