### PR TITLE
style: 💄 bold code in headers

### DIFF
--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -162,3 +162,7 @@ defaults:
       code {
         color: $primary;
       }
+
+      :is(h3, h4, h5, h6, dt) code {
+        font-weight: bold;
+      }

--- a/index.qmd
+++ b/index.qmd
@@ -47,9 +47,15 @@ A callout block:
 Some text.
 :::
 
-## Another header with `code span`
+## Another header with `code`
 
+### H3 with `code`
 
+#### H4 with `code`
+
+##### H5 with `code`
+
+###### H6 with `code`
 
 Here's some `inline code` in a sentence.
 


### PR DESCRIPTION
# Description

Following @joelostblom's implementation in [seedcase-flower#49](https://github.com/seedcase-project/seedcase-flower/pull/49/files#r2678714846), except that I didn't include bold for H1 and H2, since I think the text size makes it a bit much, see image below: 

<img width="364" height="295" alt="image" src="https://github.com/user-attachments/assets/0aa67f6f-1de6-4b93-9a6f-f3a4a8c225f7" />

This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
