### PR TITLE
refactor: 🚚 move logo out of `extension.yml`

### DIFF
--- a/_extensions/seedcase-theme/_extension.yml
+++ b/_extensions/seedcase-theme/_extension.yml
@@ -29,8 +29,6 @@ contributes:
       navbar:
         pinned: true
         background: light
-        logo: logos/navbar-logo-seedcase-project.svg
-        logo-alt: "Seedcase Project logo: Main page"
       page-footer:
         border: true
         center:

--- a/_extensions/seedcase-theme/_extension.yml
+++ b/_extensions/seedcase-theme/_extension.yml
@@ -20,7 +20,7 @@ contributes:
 
     website:
       page-navigation: true
-      favicon: favicon/favicon.ico
+      favicon: _extensions/seedcase-theme/logos/seedcase/icon.svg
       repo-branch: main
       repo-actions: [edit, issue, source]
       search:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,6 +7,8 @@ website:
   site-url: "https://seedcase-project.github.io/seedcase-theme/"
   repo-url: "https://github.com/seedcase-project/seedcase-theme"
   navbar:
+    logo: _extensions/seedcase-theme/logos/seedcase/icon.svg
+    logo-alt: "Seedcase logo"
     left:
       - text: "Welcome"
         href: index.qmd


### PR DESCRIPTION
# Description

We have different navbar logos for each website, so it doesn't make sense to set it here.
I've kept the favicon though, so that all our websites defaults to the seedcase logo as favicon if we forget to set it in the `_quarto.yml`

This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
