### PR TITLE
fix: :bug: favicon path must be relative to `_extension.yml` file

### DIFF
--- a/_extensions/seedcase-theme/_extension.yml
+++ b/_extensions/seedcase-theme/_extension.yml
@@ -20,7 +20,7 @@ contributes:
 
     website:
       page-navigation: true
-      favicon: _extensions/seedcase-theme/logos/seedcase/icon.svg
+      favicon: logos/seedcase/icon.svg
       repo-branch: main
       repo-actions: [edit, issue, source]
       search:


### PR DESCRIPTION
# Description

Couldn't build the website with the updated theme because of this.

No review needed.

## Checklist

- [x] Ran `just run-all`
