### PR TITLE
chore: :see_no_evil: auto-added Quarto ignore for ipynb files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dev/
 # Quarto
 /.quarto/
 docs/.quarto/
+**/*.quarto_ipynb
 
 # Website generation
 _site


### PR DESCRIPTION
# Description

No review needed.

## Checklist

- [x] Ran `just run-all`
