### PR TITLE
refactor: 💄 grey navbar border using Quarto css variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dev/
 # Quarto
 /.quarto/
 docs/.quarto/
+**/*.quarto_ipynb
 
 # Website generation
 _site

--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -56,7 +56,7 @@ defaults:
       }
 
       .navbar {
-          border-bottom: rgba($toc-active-border, 0.3) 1px solid;
+        border-bottom: var(--quarto-scss-export-gray-300) 1px solid;
       }
 
       svg {

--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -16,7 +16,6 @@ color:
     logo-green: "#024639"
     dark-green: "#196440"
     vibrant-green: "#48DC76"
-    dark-grey: "#8B8B8B"
     light-grey: "#F8F9FA"
     code-bg: "#E9ECEFA6"
   primary: dark-green
@@ -45,7 +44,7 @@ typography:
 defaults:
   bootstrap:
     defaults:
-      mermaid-edge-color: var(--brand-dark-grey)
+      mermaid-edge-color: var(--quarto-scss-export-gray-800)
       # Set code background colour variable so all inline code has the same colour
       # including headers with inline code.
       # This colour is the default background colour for inline code.


### PR DESCRIPTION
# Description

I noticed that the navbar border is green currently, so this changes it to the same grey that's used as underline for H2 headers (using a Quarto var). This made me realise that I could use an exported scss colour instead of having the `dark-grey` in the brand, so I've also removed that.

This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
