### PR TITLE
feat: :busts_in_silhouette: add all contributors to `authors`

### DIFF
--- a/_extensions/seedcase-theme/_extension.yml
+++ b/_extensions/seedcase-theme/_extension.yml
@@ -1,5 +1,15 @@
 title: seedcase-theme
-author: Luke W. Johnston
+authors:
+  - name: Luke W. Johnston
+    orcid: 0000-0003-4169-2616
+  - name: Signe Kirk Brødbæk
+    orcid: 0009-0000-2208-7088
+  - name: Marton Vago
+    orcid: 0009-0007-4628-655X
+  - name: Joel Ostblom
+    orcid: 0000-0003-0051-3239
+  - name: Kristiane Beicher
+    orcid: 0000-0001-7556-9566
 version: 0.6.4
 quarto-required: ">=1.7.0"
 contributes:


### PR DESCRIPTION
# Description

Added in the order of number of contributions, following the contributor insights: 

<img width="796" height="848" alt="image" src="https://github.com/user-attachments/assets/c4a7b9ad-72ee-43ff-aa24-876d6772e3de" />


This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
