### PR TITLE
fix: :bug: CSS was wrongly placed in root `.scss` file

### DIFF
--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -165,3 +165,14 @@ defaults:
       :is(h3, h4, h5, h6, dt) code {
         font-weight: bold;
       }
+
+      // Color built-ins the same as regular variables
+      // since we sometimes use built-in names as parameter names
+      span.bu {
+        color: inherit !important
+      }
+      // Color terminal executables the same as regular variables
+      // since the default has low contrast and is hard to see
+      span.ex {
+        color: inherit !important
+      }

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -24,7 +24,6 @@ format:
   seedcase-theme-html:
     theme:
       - brand
-      - custom-styles.scss
 
 editor:
   markdown:

--- a/custom-styles.scss
+++ b/custom-styles.scss
@@ -3,14 +3,3 @@
 // See the link below for an overview of the available variables
 // and how to customize them.
 // https://quarto.org/docs/output-formats/html-themes.html#sass-variables
-
-// Color built-ins the same as regular variables
-// since we sometimes use built-in names as parameter names
-span.bu {
-  color: inherit !important
-}
-// Color terminal executables the same as regular variables
-// since the default has low contrast and is hard to see
-span.ex {
-  color: inherit !important
-}

--- a/custom-styles.scss
+++ b/custom-styles.scss
@@ -1,5 +1,0 @@
-/*-- scss:defaults --*/
-
-// See the link below for an overview of the available variables
-// and how to customize them.
-// https://quarto.org/docs/output-formats/html-themes.html#sass-variables


### PR DESCRIPTION
# Description

It seems like the custom styles file in not shipped with the extension. Putting the rules in the brand file seems to work locally and I see there is other css there as well. Worked for me locally too.

This PR needs a quick review.

