### PR TITLE
feat: :lipstick: use a horizontal line to separate `description` content

### DIFF
--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -176,3 +176,9 @@ defaults:
       span.ex {
         color: inherit !important
       }
+
+      // To have more separation between the description and the rest of the content on the landing page.
+      .description {
+        border-bottom: 1px solid #dee2e6;
+        padding-bottom: .5rem;
+      }

--- a/_extensions/seedcase-theme/_brand.yml
+++ b/_extensions/seedcase-theme/_brand.yml
@@ -177,7 +177,7 @@ defaults:
         color: inherit !important
       }
 
-      // To have more separation between the description and the rest of the content on the landing page.
+      // To have more separation between the description and the rest of the content.
       .description {
         border-bottom: 1px solid #dee2e6;
         padding-bottom: .5rem;

--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Welcome"
+description: "This is an example page to show how the styling works."
 ---
 
 ## Introduction


### PR DESCRIPTION
# Description

The description field and the starting paragraph/body blends into one another. This puts a horizontal line, like used below headers, right below the description.

Closes #196

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
